### PR TITLE
Render markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "pin-project-lite",
  "port_check",
  "predicates",
+ "pulldown-cmark",
  "regex",
  "reqwest",
  "rstest",
@@ -736,6 +737,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1356,6 +1366,25 @@ checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d31cbfcd94884c3a67ec210c83efb06cb43674043458b0ad59f6947f8462c23"
+dependencies = [
+ "bitflags 2.5.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -2046,6 +2075,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dufs-proxy"
-version = "0.41.4"
+version = "0.41.5"
 dependencies = [
  "alphanumeric-sort",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dufs-proxy"
-version = "0.41.4"
+version = "0.41.5"
 edition = "2021"
 authors = ["sigoden <sigoden@gmail.com>", "senstar-aacker"]
 description = "Dufs is a distinctive utility file server (with dufs-proxy modification)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ http-body-util = "0.1"
 bytes = "1.5"
 pin-project-lite = "0.2"
 sha2 = "0.10.8"
+pulldown-cmark = "0.12.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Dufs is a distinctive utility file server that supports static serving, uploadin
 - Hard-coded proxy url in src/server.rs variable name ``GET_PROXY_URL``
 - Only major code change is on GET if request is a file and file doesn't exist then first try to download the file from the proxy and send it on success
 - Removed TLS support and relevant crate dependencies to lower compile times and file size
+- Render README.md file if found in a directory to the file index page (similar to how GitHub renders markdown in repo folders)
 
 ## Features
 

--- a/assets/index.css
+++ b/assets/index.css
@@ -217,6 +217,27 @@ body {
   padding: 5px;
 }
 
+div.mdreadme {
+  border: 1px solid #ced4da;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  transition: box-shadow 0.3s ease-in-out;
+  margin-top: 1em;
+  margin-left: 1em;
+  margin-right: 1em;
+  padding-left: 0.5em;
+  padding-top: 0.5em;
+}
+
+div.mdreadme>h1 {
+  padding-top: 0px;
+  margin-top: 0px;
+}
+
+div.mdreadme:hover {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+}
+
 .toolbox-right {
   margin-left: auto;
   margin-right: 2em;

--- a/assets/index.html
+++ b/assets/index.html
@@ -123,7 +123,7 @@
     </div>
   </div>
   <template id="index-data">__INDEX_DATA__</template>
-  <div id="markdown-readme">__MARKDOWN_README__</div>
+  <div class="mdreadme hidden">__MARKDOWN_README__</div>
   <script src="__ASSETS_PREFIX__index.js"></script>
 </body>
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -123,6 +123,7 @@
     </div>
   </div>
   <template id="index-data">__INDEX_DATA__</template>
+  <div id="markdown-readme">__MARKDOWN_README__</div>
   <script src="__ASSETS_PREFIX__index.js"></script>
 </body>
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -61,6 +61,7 @@ const INDEX_NAME: &str = "index.html";
 const BUF_SIZE: usize = 65536;
 const EDITABLE_TEXT_MAX_SIZE: u64 = 4194304; // 4M
 const RESUMABLE_UPLOAD_MIN_SIZE: u64 = 20971520; // 20M
+const MARKDOWN_README_TEXT_MAX_SIZE: u64 = 1048576; // 1M
 
 pub struct Server {
     args: Args,
@@ -564,6 +565,7 @@ impl Server {
             access_paths,
             res,
         )
+        .await
     }
 
     async fn handle_search_dir(
@@ -644,6 +646,7 @@ impl Server {
             access_paths,
             res,
         )
+        .await
     }
 
     async fn handle_zip_dir(
@@ -948,7 +951,8 @@ impl Server {
                 "__ASSETS_PREFIX__",
                 &format!("{}{}", self.args.uri_prefix, self.assets_prefix),
             )
-            .replace("__INDEX_DATA__", &serde_json::to_string(&data)?);
+            .replace("__INDEX_DATA__", &serde_json::to_string(&data)?)
+            .replace("__MARKDOWN_README__", "");
         res.headers_mut()
             .typed_insert(ContentLength(output.as_bytes().len() as u64));
         if head_only {
@@ -1114,7 +1118,7 @@ impl Server {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn send_index(
+    async fn send_index(
         &self,
         path: &Path,
         mut paths: Vec<PathItem>,
@@ -1170,6 +1174,12 @@ impl Server {
             normalize_path(path.strip_prefix(&self.args.serve_path)?)
         );
         let readwrite = access_paths.perm().readwrite();
+
+        let maybe_readme = paths
+            .iter()
+            .find(|p| p.base_name().to_lowercase() == "readme.md")
+            .cloned();
+
         let data = IndexData {
             kind: DataKind::Index,
             href,
@@ -1190,12 +1200,18 @@ impl Server {
         } else {
             res.headers_mut()
                 .typed_insert(ContentType::from(mime_guess::mime::TEXT_HTML_UTF_8));
-            self.html
-                .replace(
-                    "__ASSETS_PREFIX__",
-                    &format!("{}{}", self.args.uri_prefix, self.assets_prefix),
-                )
+            let new_html = self.html.replace(
+                "__ASSETS_PREFIX__",
+                &format!("{}{}", self.args.uri_prefix, self.assets_prefix),
+            );
+            new_html
                 .replace("__INDEX_DATA__", &serde_json::to_string(&data)?)
+                .replace(
+                    "__MARKDOWN_README__",
+                    &Server::get_and_render_markdown(path, maybe_readme)
+                        .await
+                        .unwrap_or(String::new()),
+                )
         };
         res.headers_mut()
             .typed_insert(ContentLength(output.as_bytes().len() as u64));
@@ -1210,6 +1226,29 @@ impl Server {
         }
         *res.body_mut() = body_full(output);
         Ok(())
+    }
+
+    async fn get_and_render_markdown(
+        base_path: &Path,
+        maybe_readme: Option<PathItem>,
+    ) -> Result<String> {
+        if let Some(path_item) = maybe_readme {
+            println!("Found README.md!");
+            let path = &base_path.join(&path_item.name);
+            let (file, meta) = tokio::join!(fs::File::open(path), fs::metadata(path),);
+            let (mut file, meta) = (file?, meta?);
+            // sanity limits on markdown size
+            if meta.len() <= MARKDOWN_README_TEXT_MAX_SIZE {
+                let mut contents = String::new();
+                file.read_to_string(&mut contents).await?;
+                // now need to render the markdown
+                let parser = pulldown_cmark::Parser::new(&contents);
+                let mut output = String::new();
+                pulldown_cmark::html::push_html(&mut output, parser);
+                return Ok(output);
+            }
+        }
+        Ok(String::new())
     }
 
     fn auth_reject(&self, res: &mut Response) -> Result<()> {
@@ -1409,7 +1448,7 @@ struct EditData {
     editable: bool,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 struct PathItem {
     path_type: PathType,
     name: String,
@@ -1504,7 +1543,7 @@ impl PathItem {
     }
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Eq, PartialEq)]
 enum PathType {
     Dir,
     SymlinkDir,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1175,7 +1175,7 @@ impl Server {
         );
         let readwrite = access_paths.perm().readwrite();
 
-        let maybe_readme = paths
+        let maybe_readme_md = paths
             .iter()
             .find(|p| p.base_name().to_lowercase() == "readme.md")
             .cloned();
@@ -1208,7 +1208,7 @@ impl Server {
                 .replace("__INDEX_DATA__", &serde_json::to_string(&data)?)
                 .replace(
                     "__MARKDOWN_README__",
-                    &Server::get_and_render_markdown(path, maybe_readme)
+                    &Server::get_and_render_markdown(path, maybe_readme_md)
                         .await
                         .unwrap_or(String::new()),
                 )
@@ -1230,9 +1230,9 @@ impl Server {
 
     async fn get_and_render_markdown(
         base_path: &Path,
-        maybe_readme: Option<PathItem>,
+        maybe_readme_md: Option<PathItem>,
     ) -> Result<String> {
-        if let Some(path_item) = maybe_readme {
+        if let Some(path_item) = maybe_readme_md {
             println!("Found README.md!");
             let path = &base_path.join(&path_item.name);
             let (file, meta) = tokio::join!(fs::File::open(path), fs::metadata(path),);


### PR DESCRIPTION
- render markdown on file index page if readme.md exists
- 1Mb size limit for the file to be rendered in the page